### PR TITLE
fix: unexpected comma on podcasts json file

### DIFF
--- a/data/podcasts.json
+++ b/data/podcasts.json
@@ -1413,5 +1413,5 @@
     "twitter_at":"dataskeptic",
     "image":"https://static.libsyn.com/p/assets/2/9/3/8/2938570bb173ccbc/DataSkeptic-Podcast-1A.jpg",
     "language":"en"
-  },
+  }
 ]


### PR DESCRIPTION
Oi @ogilvieira tudo blz?

Acessei o site e vi que não estava funcionado. Bom, tudo por causa de uma vírgulo no final do arquivo. Abri um PR removendo, basta mergear. 

abs