### PR TITLE
feature: adding travis-ci validation for podcasts.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+sudo: false
+
+language: node_js
+
+before_script:
+  - npm install
+
+script:
+ - jshint data/podcasts.json

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "grunt-contrib-concat": "^1.0.1",
     "grunt-contrib-cssmin": "^1.0.2",
     "grunt-contrib-uglify": "^2.0.0",
-    "grunt-contrib-watch": "^1.0.0"
+    "grunt-contrib-watch": "^1.0.0",
+    "jshint": "~2.8.0"
   }
 }


### PR DESCRIPTION
A few days ago, I visited this repo site and a problem was ocurring. During the investigation I found a sintax error on podcasts.json: unexpected comma. So I opened a PR fixing this.

But this is basic error, so I think will be great if we have an automate way to garantee that problems like that doesn't ocurr anymore. With Travis-CI we can do that.